### PR TITLE
Поддержка признаков способа расчета и типов товара

### DIFF
--- a/src/Object/Item.php
+++ b/src/Object/Item.php
@@ -10,6 +10,131 @@ namespace SSitdikov\ATOL\Object;
  */
 class Item implements \JsonSerializable
 {
+    
+    /**
+     * товар
+     */
+    public const PAYMENT_OBJECT_COMMODITY = 'commodity';
+
+    /**
+     * подакцизный товар
+     */
+    public const PAYMENT_OBJECT_EXCISE = 'excise';
+
+    /**
+     * работа
+     */
+    public const PAYMENT_OBJECT_JOB = 'job';
+
+    /**
+     * услуга
+     */
+    public const PAYMENT_OBJECT_SERVICE = 'service';
+
+    /**
+     * ставка азартной игры
+     */
+    public const PAYMENT_OBJECT_GAMBLING_BET = 'gambling_bet';
+
+    /**
+     * выигрыш азартной игры
+     */
+    public const PAYMENT_OBJECT_GAMBLING_PRIZE = 'gambling_prize';
+
+    /**
+     * лотерейный билет
+     */
+    public const PAYMENT_OBJECT_LOTTERY = 'lottery';
+
+    /**
+     * выигрыш лотереи
+     */
+    public const PAYMENT_OBJECT_LOTTERY_PRIZE = 'lottery_prize';
+
+    /**
+     * предоставление результатов интеллектуальной деятельности
+     */
+    public const PAYMENT_OBJECT_INTELLECTUAL_ACTIVITY = 'intellectual_activity';
+
+    /**
+     * платеж
+     */
+    public const PAYMENT_OBJECT_PAYMENT = 'payment';
+
+    /**
+     * агентское вознаграждение
+     */
+    public const PAYMENT_OBJECT_AGENT_COMMISSION = 'agent_commission';
+
+    /**
+     * составной предмет расчета
+     */
+    public const PAYMENT_OBJECT_COMPOSITE = 'composite';
+
+    /**
+     * иной предмет расчета
+     */
+    public const PAYMENT_OBJECT_ANOTHER = 'another';
+
+    /**
+     * имущественное право
+     */
+    public const PAYMENT_OBJECT_PROPERTY_RIGHT = 'property_right';
+
+    /**
+     * внереализационный доход
+     */
+    public const PAYMENT_OBJECT_NON_OPERATING_GAIN = 'non-operating_gain';
+
+    /**
+     * страховые взносы
+     */
+    public const PAYMENT_OBJECT_INSURANCE_PREMIUM = 'insurance_premium';
+
+    /**
+     * торговый сбор
+     */
+    public const PAYMENT_OBJECT_SALES_TAX = 'sales_tax';
+
+    /**
+     * курортный сбор
+     */
+    public const PAYMENT_OBJECT_RESORT_FEE = 'resort_fee';
+
+    /**
+     *  предоплата 100%. Полная предварительная оплата до момента передачи предмета расчета
+     */
+    public const PAYMENT_METHOD_FULL_PREPAYMENT = 'full_prepayment';
+
+    /**
+     * предоплата. Частичная предварительная оплата до момента передачи предмета расчета
+     */
+    public const PAYMENT_METHOD_PREPAYMENT = 'prepayment';
+
+    /**
+     * аванс
+     */
+    public const PAYMENT_METHOD_ADVANCE = 'advance';
+
+    /**
+     * полный расчет. Полная оплата, в том числе с учетом аванса (предварительной оплаты) в момент передачи предмета расчета.
+     */
+    public const PAYMENT_METHOD_FULL_PAYMENT = 'full_payment';
+
+    /**
+     *  частичный расчет и кредит. Частичная оплата предмета расчета в момент его передачи с последующей оплатой в кредит.
+     */
+    public const PAYMENT_METHOD_PARTIAL_PAYMENT = 'partial_payment';
+
+    /**
+     * передача в кредит. Передача предмета расчета без его оплаты в момент его передачи с последующей оплатой в кредит
+     */
+    public const PAYMENT_METHOD_CREDIT = 'credit';
+
+    /**
+     * оплата кредита. Оплата предмета расчета после его передачи с оплатой в кредит (оплата кредита)
+     */
+    public const PAYMENT_METHOD_CREDIT_PAYMENT = 'credit_payment';
 
     public const TAX_NONE = 'none';
     public const TAX_VAT0 = 'vat0';
@@ -24,6 +149,18 @@ class Item implements \JsonSerializable
     private $name = '';
     private $price = 0.0;
     private $quantity = 1.0;
+    /**
+     * @var string $payment_object Признак предмета расчета
+     */
+    private $payment_object = 'commodity';
+    /**
+     * @var string $payment_method Признак способа расчета
+     */
+    private $payment_method = 'full_prepayment';
+    /**
+     * @var string $measurement_unit Единица измерения предмета расчета
+     */
+    private $measurement_unit = 'шт.';
 
     /**
      * Продаваемый товар по чеку
@@ -31,14 +168,18 @@ class Item implements \JsonSerializable
      * @param float $price
      * @param float $quantity
      * @param string $tax
+     * @param string $payment_object
+     * @param string $payment_method
      */
-    public function __construct($name, $price, $quantity, $tax)
+    public function __construct($name, $price, $quantity, $tax, $payment_object = 'commodity', $payment_method = 'full_payment')
     {
         $this->setName($name);
         $this->setPrice($price);
         $this->setQuantity($quantity);
         $this->setTax($tax);
         $this->setSum($price * $quantity);
+        $this->setPaymentObject($payment_object);
+        $this->setPaymentMethod($payment_method);
     }
 
     /**
@@ -52,8 +193,42 @@ class Item implements \JsonSerializable
             'quantity' => $this->getQuantity(),
             'sum' => $this->getSum(),
             'tax' => $this->getTax(),
-            'tax_sum' => $this->getTaxSum()
+            'tax_sum' => $this->getTaxSum(),
+            'payment_object' => $this->getPaymentObject(),
+            'payment_method' => $this->getPaymentMethod(),
         ];
+    }
+    
+    /**
+     * @return string
+     */
+    public function getPaymentObject(): string
+    {
+        return $this->payment_object;
+    }
+
+    /**
+     * @param string $payment_object
+     */
+    public function setPaymentObject(string $payment_object): void
+    {
+        $this->payment_object = $payment_object;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentMethod(): string
+    {
+        return $this->payment_method;
+    }
+
+    /**
+     * @param string $payment_method
+     */
+    public function setPaymentMethod(string $payment_method): void
+    {
+        $this->payment_method = $payment_method;
     }
 
     /**


### PR DESCRIPTION
Добавил в Item поддержку указания признака способа расчетов и типа предмета расчета, а также единиц измерения предмета расчета.
По-умолчанию оставил значения как в документации Атол, но признака способа расчетов сделал "полный расчет", потому что по документации стоит "предоплата 100%", однако это в интернет-эквайринге используется редко.